### PR TITLE
add new global roles to rhacs oauth config

### DIFF
--- a/isar-apps/acs/declarative-oauth.yaml
+++ b/isar-apps/acs/declarative-oauth.yaml
@@ -14,6 +14,12 @@ data:
         - key: groups
           value: coe-sso-admin
           role: Admin
+        - key: groups
+          value: global-cluster-admins
+          role: Admin
+        - key: groups
+          value: global-cluster-reader
+          role: Analyst
     openshift:
         enable: true
 kind: ConfigMap


### PR DESCRIPTION
after our reconfig, we should also add the global roles to the RHACS configuration, to allow openshift oauth integration