### PR TITLE
Add pool.kubevirt.io priviledges for Argo

### DIFF
--- a/apps/gitops-privileges/ClusterRole.yaml
+++ b/apps/gitops-privileges/ClusterRole.yaml
@@ -258,5 +258,5 @@ rules:
   resources:
   - virtualmachinepools
   verbs:
-  - create
   - patch
+  - create


### PR DESCRIPTION
With this, Argo can deploy and patch `VirtualMachinePools`. 