### PR TITLE
Add gitops privileges for resource routes for API group route.openshift.io to 

### DIFF
--- a/apps/gitops-privileges/ClusterRole.yaml
+++ b/apps/gitops-privileges/ClusterRole.yaml
@@ -260,3 +260,10 @@ rules:
   verbs:
   - patch
   - create
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - patch
+  - create


### PR DESCRIPTION
This PR will add privileges for resource `routes` for API group `route.openshift.io to`.

Closes: #22