### PR TITLE
add VM vulnerability scanning for ocp-v in rhacs

### DIFF
--- a/isar-apps/acs/operator.yaml
+++ b/isar-apps/acs/operator.yaml
@@ -111,3 +111,12 @@ spec:
         minReplicas: 2
         replicas: 3
     scannerComponent: Enabled
+  overlays:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: central
+      patches:
+        - path: spec.template.spec.containers[name:central].env[-1]
+          value: |
+            name: ROX_VIRTUAL_MACHINES
+            value: "true"

--- a/isar-apps/acs/secured-cluster.yaml
+++ b/isar-apps/acs/secured-cluster.yaml
@@ -12,3 +12,20 @@ spec:
     listenOnCreates: true
     listenOnEvents: true
     listenOnUpdates: true
+  overlays:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: sensor
+      patches:
+        - path: spec.template.spec.containers[name:sensor].env[-1]
+          value: |
+            name: ROX_VIRTUAL_MACHINES
+            value: "true"
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: collector
+      patches:
+        - path: spec.template.spec.containers[name:compliance].env[-1]
+          value: |
+            name: ROX_VIRTUAL_MACHINES
+            value: "true"

--- a/isar-apps/ocp-v/HyperConverged.yaml
+++ b/isar-apps/ocp-v/HyperConverged.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openshift-cnv
   annotations:
     argocd.argoproj.io/sync-wave: "100"
-    kubevirt.kubevirt.io/jsonpatch: '[ {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "VolumesUpdateStrategy"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "VolumeMigration"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "Sidecar"} ]'
+    kubevirt.kubevirt.io/jsonpatch: '[ {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "VolumesUpdateStrategy"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "VolumeMigration"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "Sidecar"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-","value": "VSOCK"} ]'
 spec:
   defaultCPUModel: IvyBridge-v2
   # https://github.com/stormshift/support/issues/248


### PR DESCRIPTION
This enables VM Scanning in RHACS following https://access.redhat.com/solutions/7133102

I tested this in my own environment before endangering isar, but do not have an ocp-v infra, so only the rhacs configuration patterns are tested and confirmed.

As this is limited to RHEL VMs which deploy and run roxagent, I do not expect a lot of impact out side of clear test-cases.

Furthermore be aware, that this is DEVELOPER PREVIEW at the moment.