### PR TITLE
disable stackrox-scanner component

### DIFF
--- a/isar-apps/acs/operator.yaml
+++ b/isar-apps/acs/operator.yaml
@@ -104,13 +104,7 @@ spec:
         replicas: 3
     scannerComponent: Enabled
   scanner:
-    analyzer:
-      scaling:
-        autoScaling: Enabled
-        maxReplicas: 5
-        minReplicas: 2
-        replicas: 3
-    scannerComponent: Enabled
+    scannerComponent: Disabled
   overlays:
     - apiVersion: apps/v1
       kind: Deployment


### PR DESCRIPTION
stackrox scanner is deprecated (see https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.10/html-single/release_notes/release_notes#deprecated-and-removed-features_release-notes-410 )

and as Scanner V4 can scan nodes now, there is no value in still running it.

This configuration was tested against other rhacs clusters (for example on ocp22) already.