### PR TITLE
Remove declarative-oauth.yaml from kustomization

### DIFF
--- a/isar-apps/acs/kustomization.yaml
+++ b/isar-apps/acs/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
 - ExternalSecret/
 - cluster-init.yaml
 - console-link.yaml
-- declarative-oauth.yaml
 - operator.yaml
 - rbac.yaml
 - secured-cluster.yaml


### PR DESCRIPTION
Removed 'declarative-oauth.yaml' from resources list.

Forgot this in the last PR. Now GitOps aint working